### PR TITLE
feat: What's New changelog drawer with release notification badge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,71 @@ jobs:
           $versionFile.version = $version
           $versionFile.releaseDate = (Get-Date -Format "yyyy-MM-dd")
           $versionFile | ConvertTo-Json -Depth 10 | Set-Content "version.json"
-      
+
+      - name: Generate public/version.json from CHANGELOG.md
+        shell: pwsh
+        run: |
+          $version = "${{ steps.get_version.outputs.VERSION }}"
+
+          $lines = Get-Content "CHANGELOG.md"
+          $releases = [System.Collections.Generic.List[object]]::new()
+          $current = $null
+          $currentSection = $null
+
+          foreach ($line in $lines) {
+            if ($line -match '^\#\# \[(.+?)\] - (\d{4}-\d{2}-\d{2})') {
+              if ($current) { $releases.Add($current) }
+              $current = @{
+                version = $matches[1]
+                date    = $matches[2]
+                title   = ''
+                changes = @{ added = @(); changed = @(); fixed = @(); removed = @() }
+              }
+              $currentSection = $null
+              continue
+            }
+            if (-not $current) { continue }
+            # First plain text line after the version heading = optional release title
+            if ($current.title -eq '' -and $line.Trim() -ne '' -and
+                $line -notmatch '^\#' -and $line -notmatch '^-' -and $line -notmatch '^>') {
+              $current.title = $line.Trim()
+              continue
+            }
+            # Section heading — only track the four standard categories
+            if ($line -match '^\#\#\# (.+)') {
+              $name = $matches[1].Trim()
+              $currentSection = if ($name -in 'Added','Changed','Fixed','Removed') { $name.ToLower() } else { $null }
+              continue
+            }
+            # List item
+            if ($currentSection -and $line -match '^- (.+)') {
+              $current.changes[$currentSection] += $matches[1].Trim()
+            }
+          }
+          if ($current) { $releases.Add($current) }
+
+          $manifest = [ordered]@{
+            currentVersion = $version
+            releasedAt     = (Get-Date -Format "yyyy-MM-dd")
+            releases       = @($releases | ForEach-Object {
+              [ordered]@{
+                version = $_.version
+                date    = $_.date
+                title   = $_.title
+                changes = [ordered]@{
+                  added   = @($_.changes.added)
+                  changed = @($_.changes.changed)
+                  fixed   = @($_.changes.fixed)
+                  removed = @($_.changes.removed)
+                }
+              }
+            })
+          }
+
+          $outPath = "Timekeeper.Web\public\version.json"
+          $manifest | ConvertTo-Json -Depth 10 | Set-Content $outPath -Encoding UTF8
+          Write-Host "[SUCCESS] $outPath updated — $($releases.Count) release(s), currentVersion=$version"
+
       - name: Setup code signing
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,27 @@
 
 All notable changes to this project are documented in this file.
 
+> **Format note:** Each version heading may be followed by an optional one-line title.
+> This title is automatically picked up by the in-app "What's New" changelog drawer.
+
+## [3.0.0] - 2026-03-03
+AI Assistant & Smart Workflow Tools
+
+### Added
+- AI Assistant chat with streaming responses and full tool-calling support.
+- ERP import via AI: create customers, projects, and tasks from natural language with preview-before-create workflow.
+- AI Task Picker on Dashboard: describe your work in plain language and let AI resolve the matching task.
+- Polish Note button on all note fields: rewrites raw notes into professional invoice-ready language.
+- Configurable AI output language (11 languages: English, German, French, Hungarian, and more).
+- Chat history persisted across navigation sessions.
+- In-app "What's New" changelog drawer with release notification badge.
+
+### Changed
+- Settings page now includes AI configuration section for admins (API token, enable/disable, connection test).
+- Settings page now includes AI Output Language preference for all users.
+
 ## [3.0.0-rc1] - 2026-02-23
+Multi-User Workspace Foundation
 
 ### Added
 - Workspace and user domain foundation for multi-user/self-hosted deployments.
@@ -26,6 +46,7 @@ All notable changes to this project are documented in this file.
 - Frontend production build: successful.
 
 ## [1.0.0] - 2026-02-05
+Initial Release
 
 ### Added
 - Initial release with core time tracking, CRUD operations, filtering/search, import/export, and reporting.

--- a/Timekeeper.Web/public/version.json
+++ b/Timekeeper.Web/public/version.json
@@ -1,0 +1,81 @@
+﻿{
+    "currentVersion":  "3.0.0",
+    "releasedAt":  "2026-03-03",
+    "releases":  [
+                     {
+                         "version":  "3.0.0",
+                         "date":  "2026-03-03",
+                         "title":  "AI Assistant \u0026 Smart Workflow Tools",
+                         "changes":  {
+                                         "added":  [
+                                                       "AI Assistant chat with streaming responses and full tool-calling support.",
+                                                       "ERP import via AI: create customers, projects, and tasks from natural language with preview-before-create workflow.",
+                                                       "AI Task Picker on Dashboard: describe your work in plain language and let AI resolve the matching task.",
+                                                       "Polish Note button on all note fields: rewrites raw notes into professional invoice-ready language.",
+                                                       "Configurable AI output language (11 languages: English, German, French, Hungarian, and more).",
+                                                       "Chat history persisted across navigation sessions.",
+                                                       "In-app \"What\u0027s New\" changelog drawer with release notification badge."
+                                                   ],
+                                         "changed":  [
+                                                         "Settings page now includes AI configuration section for admins (API token, enable/disable, connection test).",
+                                                         "Settings page now includes AI Output Language preference for all users."
+                                                     ],
+                                         "fixed":  [
+
+                                                   ],
+                                         "removed":  [
+
+                                                     ]
+                                     }
+                     },
+                     {
+                         "version":  "3.0.0-rc1",
+                         "date":  "2026-02-23",
+                         "title":  "Multi-User Workspace Foundation",
+                         "changes":  {
+                                         "added":  [
+                                                       "Workspace and user domain foundation for multi-user/self-hosted deployments.",
+                                                       "Role-based access control policies for Admin and Manager capabilities.",
+                                                       "Time entry lifecycle states: Draft, Submitted, Approved, Rejected, Locked.",
+                                                       "Time entry lifecycle transition endpoints (`submit`, `approve`, `reject`, `lock`, `reopen`).",
+                                                       "Workspace context and membership management APIs.",
+                                                       "Reports page chart-section lazy loading and improved empty-state actions.",
+                                                       "Development login screen with role/workspace options and sign-out support.",
+                                                       "Admin user maintenance UI in Settings (create user, role update, activate/deactivate)."
+                                                   ],
+                                         "changed":  [
+                                                         "Core entity access patterns now use tenant-safe query paths under workspace scoping.",
+                                                         "Mutating API endpoints now enforce role-aware authorization rules.",
+                                                         "Frontend routing/chunk strategy refined to reduce initial bundle cost.",
+                                                         "Timer pause/resume duration tests made deterministic (no `Task.Delay` dependence).",
+                                                         "Time entries, work days, breaks, and reports are now filtered to the current logged-in user."
+                                                     ],
+                                         "fixed":  [
+
+                                                   ],
+                                         "removed":  [
+
+                                                     ]
+                                     }
+                     },
+                     {
+                         "version":  "1.0.0",
+                         "date":  "2026-02-05",
+                         "title":  "Initial Release",
+                         "changes":  {
+                                         "added":  [
+                                                       "Initial release with core time tracking, CRUD operations, filtering/search, import/export, and reporting."
+                                                   ],
+                                         "changed":  [
+
+                                                     ],
+                                         "fixed":  [
+
+                                                   ],
+                                         "removed":  [
+
+                                                     ]
+                                     }
+                     }
+                 ]
+}

--- a/Timekeeper.Web/src/components/Layout/ChangelogDrawer.tsx
+++ b/Timekeeper.Web/src/components/Layout/ChangelogDrawer.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react'
+import { X, Sparkles, ChevronDown, ChevronRight } from 'lucide-react'
+import { Badge } from '../ui/Badge'
+import { Button } from '../ui/Button'
+import { cn } from '../../lib/utils'
+import { type Release, useChangelog } from '../../hooks/useChangelog'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+const CATEGORY_CONFIG = {
+  added:   { label: 'Added',   color: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300' },
+  changed: { label: 'Changed', color: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300' },
+  fixed:   { label: 'Fixed',   color: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300' },
+  removed: { label: 'Removed', color: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300' },
+} as const
+
+function ReleaseCard({ release, defaultOpen }: { release: Release; defaultOpen: boolean }) {
+  const [expanded, setExpanded] = useState(defaultOpen)
+  const hasContent = (Object.keys(CATEGORY_CONFIG) as Array<keyof typeof CATEGORY_CONFIG>)
+    .some(k => release.changes[k].length > 0)
+
+  return (
+    <div className="rounded-lg border bg-card overflow-hidden">
+      {/* Card header — always visible */}
+      <button
+        onClick={() => setExpanded(v => !v)}
+        className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-accent/50 transition-colors"
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          <Badge variant="outline" className="font-mono text-xs flex-shrink-0">
+            v{release.version}
+          </Badge>
+          {release.title && (
+            <span className="text-sm font-medium truncate">{release.title}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+          <span className="text-xs text-muted-foreground">{release.date}</span>
+          {hasContent && (
+            expanded
+              ? <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              : <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+        </div>
+      </button>
+
+      {/* Expandable content */}
+      {expanded && hasContent && (
+        <div className="px-4 pb-4 space-y-3 border-t pt-3">
+          {(Object.entries(CATEGORY_CONFIG) as Array<[keyof typeof CATEGORY_CONFIG, (typeof CATEGORY_CONFIG)[keyof typeof CATEGORY_CONFIG]]>)
+            .map(([key, cfg]) => {
+              const items = release.changes[key]
+              if (items.length === 0) return null
+              return (
+                <div key={key}>
+                  <span className={cn('inline-block text-xs font-semibold px-2 py-0.5 rounded mb-2', cfg.color)}>
+                    {cfg.label}
+                  </span>
+                  <ul className="space-y-1">
+                    {items.map((item, i) => (
+                      <li key={i} className="flex gap-2 text-sm text-muted-foreground">
+                        <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-muted-foreground/50" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )
+            })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function ChangelogDrawer({ open, onClose }: Props) {
+  const { releases, currentVersion, markAsSeen, loading } = useChangelog()
+
+  // Mark as seen immediately when drawer opens
+  useEffect(() => {
+    if (open) {
+      markAsSeen()
+    }
+  }, [open])
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={cn(
+          'fixed inset-0 z-40 bg-black/30 backdrop-blur-sm transition-opacity duration-300',
+          open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        )}
+        onClick={onClose}
+      />
+
+      {/* Drawer panel */}
+      <div
+        className={cn(
+          'fixed inset-y-0 right-0 z-50 flex w-full flex-col bg-background shadow-2xl transition-transform duration-300 ease-in-out sm:w-[480px]',
+          open ? 'translate-x-0' : 'translate-x-full'
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b px-6 py-4 flex-shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-purple-600 to-pink-600">
+              <Sparkles className="h-4 w-4 text-white" />
+            </div>
+            <div>
+              <h2 className="text-base font-semibold">What's New</h2>
+              {currentVersion && (
+                <p className="text-xs text-muted-foreground">Latest: v{currentVersion}</p>
+              )}
+            </div>
+          </div>
+          <Button variant="ghost" size="icon" onClick={onClose}>
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-3">
+          {loading && (
+            <div className="flex items-center justify-center py-16 text-muted-foreground text-sm">
+              Loading release notes…
+            </div>
+          )}
+          {!loading && releases.length === 0 && (
+            <div className="flex items-center justify-center py-16 text-muted-foreground text-sm">
+              No release notes available.
+            </div>
+          )}
+          {!loading && releases.map((release, i) => (
+            <ReleaseCard key={release.version} release={release} defaultOpen={i === 0} />
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t px-6 py-3 flex-shrink-0">
+          <p className="text-xs text-muted-foreground text-center">
+            Timekeeper release history • All times are UTC
+          </p>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/Timekeeper.Web/src/components/Layout/Sidebar.tsx
+++ b/Timekeeper.Web/src/components/Layout/Sidebar.tsx
@@ -17,7 +17,8 @@ import {
   ChevronRight,
   Wifi,
   WifiOff,
-  Bot
+  Bot,
+  Sparkles
 } from 'lucide-react'
 import { useConnectionStatus } from '../../hooks/useConnectionStatus'
 import { cn } from '../../lib/utils'
@@ -26,6 +27,8 @@ import { Badge } from '../ui/Badge'
 import { useState } from 'react'
 import { useWorkspaceContext } from '../../hooks/useWorkspaceContext'
 import { supportApi, aiApi } from '../../api'
+import { useChangelog } from '../../hooks/useChangelog'
+import { ChangelogDrawer } from './ChangelogDrawer'
 
 const baseNavigation = [
   { name: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
@@ -45,8 +48,10 @@ const baseNavigation = [
 export function Sidebar() {
   const location = useLocation()
   const [collapsed, setCollapsed] = useState(false)
+  const [changelogOpen, setChangelogOpen] = useState(false)
   const { data: workspaceContext } = useWorkspaceContext()
   const isAdminUser = workspaceContext?.currentUser.role === 'Admin'
+  const { newReleaseCount } = useChangelog()
 
   const { data: aiStatus } = useQuery({
     queryKey: ['ai', 'status'],
@@ -131,6 +136,33 @@ export function Sidebar() {
             </Link>
           )
         })}
+        {/* What's New button */}
+        <button
+          onClick={() => setChangelogOpen(true)}
+          className={cn(
+            'relative flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors',
+            'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+            collapsed && 'justify-center'
+          )}
+          title={collapsed ? "What's New" : undefined}
+        >
+          <span className="relative flex-shrink-0">
+            <Sparkles className="h-5 w-5" />
+            {collapsed && newReleaseCount > 0 && (
+              <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-pink-500" />
+            )}
+          </span>
+          {!collapsed && (
+            <div className="flex items-center justify-between w-full gap-2">
+              <span>What's New</span>
+              {newReleaseCount > 0 && (
+                <Badge className="min-w-5 justify-center px-1.5 py-0 bg-gradient-to-r from-purple-600 to-pink-600 text-white border-0">
+                  {newReleaseCount}
+                </Badge>
+              )}
+            </div>
+          )}
+        </button>
       </nav>
 
       {/* Footer */}
@@ -150,6 +182,7 @@ export function Sidebar() {
           </div>
         </div>
       )}
+      <ChangelogDrawer open={changelogOpen} onClose={() => setChangelogOpen(false)} />
     </div>
   )
 }

--- a/Timekeeper.Web/src/hooks/useChangelog.ts
+++ b/Timekeeper.Web/src/hooks/useChangelog.ts
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react'
+
+export interface ChangelogEntry {
+  added: string[]
+  changed: string[]
+  fixed: string[]
+  removed: string[]
+}
+
+export interface Release {
+  version: string
+  date: string
+  title: string
+  changes: ChangelogEntry
+}
+
+interface VersionManifest {
+  currentVersion: string
+  releasedAt: string
+  releases: Release[]
+}
+
+const LAST_SEEN_KEY = 'timekeeper_lastSeenVersion'
+
+/** Semver comparison: returns >0 if a > b, <0 if a < b, 0 if equal.
+ *  Pre-release versions (e.g. 3.0.0-rc1) are treated as older than their
+ *  base release (3.0.0-rc1 < 3.0.0), matching the semver spec. */
+function compareSemver(a: string, b: string): number {
+  const [aBase, aPre] = a.split('-')
+  const [bBase, bPre] = b.split('-')
+  const parseBase = (v: string) => v.split('.').map(n => parseInt(n, 10) || 0)
+  const [aMaj, aMin = 0, aPatch = 0] = parseBase(aBase)
+  const [bMaj, bMin = 0, bPatch = 0] = parseBase(bBase)
+  if (aMaj !== bMaj) return aMaj - bMaj
+  if (aMin !== bMin) return aMin - bMin
+  if (aPatch !== bPatch) return aPatch - bPatch
+  // Same base: pre-release is always less than the release
+  if (aPre && !bPre) return -1
+  if (!aPre && bPre) return 1
+  if (aPre && bPre) return aPre.localeCompare(bPre)
+  return 0
+}
+
+export function useChangelog() {
+  const [releases, setReleases] = useState<Release[]>([])
+  const [currentVersion, setCurrentVersion] = useState<string>('')
+  const [loading, setLoading] = useState(true)
+  const [lastSeenVersion, setLastSeenVersionState] = useState<string>(
+    () => localStorage.getItem(LAST_SEEN_KEY) ?? ''
+  )
+
+  useEffect(() => {
+    fetch('/version.json')
+      .then(r => r.json())
+      .then((manifest: VersionManifest) => {
+        setReleases(manifest.releases)
+        setCurrentVersion(manifest.currentVersion)
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [])
+
+  /** Number of releases newer than what the user last acknowledged */
+  const newReleaseCount = releases.filter(r =>
+    compareSemver(r.version, lastSeenVersion) > 0
+  ).length
+
+  function markAsSeen() {
+    if (!currentVersion) return
+    localStorage.setItem(LAST_SEEN_KEY, currentVersion)
+    setLastSeenVersionState(currentVersion)
+  }
+
+  return { releases, currentVersion, newReleaseCount, markAsSeen, loading }
+}

--- a/prepare-release.ps1
+++ b/prepare-release.ps1
@@ -19,6 +19,81 @@ $versionFile.version = $Version
 $versionFile.releaseDate = (Get-Date -Format "yyyy-MM-dd")
 $versionFile | ConvertTo-Json -Depth 10 | Set-Content "version.json"
 
+# Auto-generate Timekeeper.Web/public/version.json from CHANGELOG.md
+Write-Host "📋 Generating public/version.json from CHANGELOG.md..." -ForegroundColor Yellow
+
+function Parse-Changelog {
+    param([string]$Path)
+
+    $lines = Get-Content $Path
+    $releases = [System.Collections.Generic.List[object]]::new()
+    $current = $null
+    $currentSection = $null
+
+    foreach ($line in $lines) {
+        # Version heading: ## [3.1.0] - 2026-03-10
+        if ($line -match '^## \[(.+?)\] - (\d{4}-\d{2}-\d{2})') {
+            if ($current) { $releases.Add($current) }
+            $current = @{
+                version = $matches[1]
+                date    = $matches[2]
+                title   = ''
+                changes = @{ added = @(); changed = @(); fixed = @(); removed = @() }
+            }
+            $currentSection = $null
+            continue
+        }
+
+        if (-not $current) { continue }
+
+        # Optional title line: first non-empty, non-heading, non-list line after version heading
+        if ($current.title -eq '' -and $line.Trim() -ne '' -and
+            $line -notmatch '^#' -and $line -notmatch '^-') {
+            $current.title = $line.Trim()
+            continue
+        }
+
+        # Section heading: ### Added / Changed / Fixed / Removed (reset on any other ### heading)
+        if ($line -match '^### (.+)') {
+            $name = $matches[1].Trim()
+            $currentSection = if ($name -in 'Added','Changed','Fixed','Removed') { $name.ToLower() } else { $null }
+            continue
+        }
+
+        # List item
+        if ($currentSection -and $line -match '^- (.+)') {
+            $current.changes[$currentSection] += $matches[1].Trim()
+        }
+    }
+
+    if ($current) { $releases.Add($current) }
+    return $releases
+}
+
+$releases = Parse-Changelog -Path (Join-Path $PSScriptRoot "CHANGELOG.md")
+
+$publicVersionJson = [ordered]@{
+    currentVersion = $Version
+    releasedAt     = (Get-Date -Format "yyyy-MM-dd")
+    releases       = @($releases | ForEach-Object {
+        [ordered]@{
+            version = $_.version
+            date    = $_.date
+            title   = $_.title
+            changes = [ordered]@{
+                added   = @($_.changes.added)
+                changed = @($_.changes.changed)
+                fixed   = @($_.changes.fixed)
+                removed = @($_.changes.removed)
+            }
+        }
+    })
+}
+
+$publicVersionPath = Join-Path $PSScriptRoot "Timekeeper.Web\public\version.json"
+$publicVersionJson | ConvertTo-Json -Depth 10 | Set-Content $publicVersionPath -Encoding UTF8
+Write-Host "[SUCCESS] public/version.json updated with $($releases.Count) release(s)" -ForegroundColor Green
+
 # Clean previous builds
 Write-Host "🧹 Cleaning previous builds..." -ForegroundColor Yellow
 if (Test-Path ".\Release") {


### PR DESCRIPTION
Closes #87

## What's in this PR

### New files
- `Timekeeper.Web/public/version.json`  static changelog manifest (source of truth for the frontend)
- `Timekeeper.Web/src/hooks/useChangelog.ts`  fetches version.json, computes unseen release count via semver comparison, exposes markAsSeen()
- `Timekeeper.Web/src/components/Layout/ChangelogDrawer.tsx`  slide-in drawer with per-release cards, categorised change pills (Added/Changed/Fixed/Removed)

### Modified files
- `Sidebar.tsx`  What's New nav button with gradient badge (purplepink), pink dot in collapsed state, auto-dismissed on open
- `CHANGELOG.md`  added optional title lines per version heading for richer drawer display
- `prepare-release.ps1`  auto-generates public/version.json by parsing CHANGELOG.md
- `.github/workflows/release.yml`  new step generates public/version.json from CHANGELOG.md before the frontend build

## How it works
- Badge count = number of versions newer than `timekeeper_lastSeenVersion` in localStorage
- Opening the drawer immediately calls markAsSeen(), badge clears
- On next release: just add an entry to CHANGELOG.md; the pipeline regenerates version.json automatically