### PR TITLE
Fix Work Days edit shifting times by timezone offset

### DIFF
--- a/Timekeeper.Web/src/pages/WorkDays.tsx
+++ b/Timekeeper.Web/src/pages/WorkDays.tsx
@@ -186,13 +186,35 @@ export function WorkDays() {
 
   const handleSaveEdit = async () => {
     if (!editingWorkDay) return;
-    
+
+    // The datetime-local inputs provide local wall-clock values without a
+    // timezone offset. Convert them to UTC ISO strings (matching the Time
+    // Entries edit flow) so the backend stores UTC and the read path renders
+    // the correct local time instead of shifting by the browser's offset.
+    const checkIn = editForm.checkInTime ? new Date(editForm.checkInTime) : null;
+    const checkOut = editForm.checkOutTime ? new Date(editForm.checkOutTime) : null;
+
+    if (checkIn && Number.isNaN(checkIn.getTime())) {
+      toast.error('Check in time is invalid.');
+      return;
+    }
+
+    if (checkOut && Number.isNaN(checkOut.getTime())) {
+      toast.error('Check out time is invalid.');
+      return;
+    }
+
+    if (checkIn && checkOut && checkOut <= checkIn) {
+      toast.error('Check out time must be after check in time.');
+      return;
+    }
+
     try {
       await updateWorkDay.mutateAsync({
         id: editingWorkDay.id,
         data: {
-          checkInTime: editForm.checkInTime || undefined,
-          checkOutTime: editForm.checkOutTime || undefined,
+          checkInTime: checkIn ? checkIn.toISOString() : undefined,
+          checkOutTime: checkOut ? checkOut.toISOString() : undefined,
           notes: editForm.notes || undefined
         }
       });


### PR DESCRIPTION
## Problem

Editing a work day's check-in/check-out time saved the value shifted forward by the browser's timezone offset (e.g. entering `06:38 / 18:00` saved as `08:38 / 20:00`, +2h in CEST).

## Cause

The Work Days edit dialog sent the raw `datetime-local` (local wall-clock) value straight to the API, while the read path (`parseApiDateTime`) assumes API datetimes are UTC. The backend stored the local value as if it were UTC, and rendering it back in local time added the offset. The Time Entries edit flow already handled this correctly by converting to UTC via `toISOString()`.

## Fix

In `WorkDays.tsx handleSaveEdit`, convert the local input to a UTC ISO string before saving (matching the Time Entries flow), plus validation for invalid dates and checkout-before-checkin.

## Verification

- `npm run lint` (tsc --noEmit) passes.

## Note

Work days that were already edited/saved before this fix remain +2h in the DB; re-editing them once after deploy corrects them.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>